### PR TITLE
Add java pkg version name

### DIFF
--- a/roles/system_common/tasks/main.yml
+++ b/roles/system_common/tasks/main.yml
@@ -34,7 +34,7 @@
       - htop
       - iftop
       - iotop
-      - java-openjdk-devel
+      - java-1.8.0-openjdk-devel
       - kernel-devel
       - libcurl
       - libcurl-devel


### PR DESCRIPTION
Fixes the issue:
```
TASK [system_common : install dependencies] **************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failures": ["No package java-openjdk-devel available."], "msg": ["Failed to install some of the specified packages"], "rc": 1, "results": []}
```